### PR TITLE
Add NewUsage function

### DIFF
--- a/v1/usage.go
+++ b/v1/usage.go
@@ -3,11 +3,42 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 )
 
 type Usage struct {
 	Data    []UsageData
 	Product string `json:"-"`
+}
+
+// Create an instance of Usage and automatically include some usage information
+// about the runtime memory stats.
+func NewUsage(product string, data []UsageData) *Usage {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	d := []UsageData{
+		{
+			Tags: Tags{
+				"os":   runtime.GOOS,
+				"arch": runtime.GOARCH,
+			},
+			Values: Values{
+				// The values here are an arbitrary selection of fields from MemStats
+				// that look like they could be interesting when viewed in aggregate over time.
+				"alloc":             m.Alloc,
+				"heap_objects":      m.HeapObjects,
+				"num_gc":            m.NumGC,
+				"gc_pause_total_ns": m.PauseTotalNs,
+				"gc_cpu_fraction":   m.GCCPUFraction,
+			},
+		},
+	}
+
+	return &Usage{
+		Product: product,
+		Data:    append(d, data...),
+	}
 }
 
 func (u Usage) Path() string {

--- a/v1/usage_test.go
+++ b/v1/usage_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"fmt"
 	"io/ioutil"
+	"runtime"
 	"testing"
 
 	"github.com/influxdb/usage-client/v1"
@@ -13,6 +14,53 @@ func Test_Usage_Path(t *testing.T) {
 	r := require.New(t)
 	u := client.Usage{Product: "influxdb"}
 	r.Equal("/usage/influxdb", u.Path())
+}
+
+func Test_NewUsage(t *testing.T) {
+	r := require.New(t)
+	u := client.NewUsage("influxdb", []client.UsageData{
+		{
+			Tags: client.Tags{
+				"k1": "v1",
+			},
+			Values: client.Values{
+				"num": 123,
+			},
+		},
+		{
+			Tags: client.Tags{
+				"k2": "v2",
+			},
+			Values: client.Values{
+				"str": "hello",
+			},
+		},
+	})
+
+	r.Equal(u.Product, "influxdb")
+	r.Len(u.Data, 3)
+
+	// Only asserting on the interesting tags -
+	// the values are an implementation detail out of scope of tests.
+	r.Equal(u.Data[0].Tags["os"], runtime.GOOS)
+	r.Equal(u.Data[0].Tags["arch"], runtime.GOARCH)
+
+	r.Equal(u.Data[1], client.UsageData{
+		Tags: client.Tags{
+			"k1": "v1",
+		},
+		Values: client.Values{
+			"num": 123,
+		},
+	})
+	r.Equal(u.Data[2], client.UsageData{
+		Tags: client.Tags{
+			"k2": "v2",
+		},
+		Values: client.Values{
+			"str": "hello",
+		},
+	})
 }
 
 // Example of saving Usage data to the Usage API


### PR DESCRIPTION
It creates a new instance of Usage and includes an instance of UsageData
with some runtime.MemStats information.

I'm pretty sure it was appropriate to have a separate instance of UsageData for this information so that it wouldn't risk collision with keys that a consumer set on their own.

I'm less sure whether this _actually results_ in more useful usage information (as opposed to manually including this information in a constructed-by-hand instance of Usage). Thoughts?
